### PR TITLE
[Draft]feat: Add view for Kafka cluster and broker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ docker-compose up -d
 
 After the local cluster is up and running, you can generate some data to work with, 
 using`go run -tags prd ./cmd/generate`.
+
+### Run `ktea`
+
+Use `go run -tags dev cmd/ktea/main.go` to run `ktea` from the root of the repository.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,8 +3,10 @@ services:
   schema-registry:
     image: confluentinc/cp-schema-registry:latest
     hostname: schema-registry
+    platform: linux/amd64
     depends_on:
-      - broker
+      broker:
+        condition: service_healthy
     ports:
       - "8081:8081"
     environment:
@@ -16,36 +18,38 @@ services:
   broker:
     image: confluentinc/confluent-local:latest
     hostname: broker
+    platform: linux/amd64
     environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092'
       KAFKA_CONTROLLER_QUORUM_VOTERS: '1@broker:29093'
       KAFKA_LISTENERS: 'PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092'
     ports:
       - "9092:9092"
+    healthcheck:
+      test: [ "CMD", "kafka-broker-api-versions", "--bootstrap-server", "broker:29092" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
 
   kafka-init:
     image: confluentinc/cp-kafka:7.6.0
     container_name: kafka-init
     depends_on:
-      - broker
+      broker:
+        condition: service_healthy
     volumes:
       - ./kafka-init.sh:/kafka-init.sh
-    command: >
-      bash -c "
-        echo 'Waiting for Kafka to be ready...'
-        while ! nc -z broker 29092; do
-          sleep 1
-        done
-        echo 'Kafka is ready!'
-        bash /kafka-init.sh
-      "
+    command: [ "/bin/bash", "-c", "/kafka-init.sh; " ]
 
   kafka-connect:
     image: confluentinc/cp-kafka-connect-base:latest
     container_name: kafka-connect
+    platform: linux/amd64
     depends_on:
-      - broker
-      - schema-registry
+      broker:
+        condition: service_healthy
     ports:
       - 8083:8083
     environment:
@@ -84,3 +88,15 @@ services:
         /etc/confluent/docker/run &
         #
         sleep infinity
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local-dev
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: broker:29092
+      KAFKA_CLUSTERS_0_METRICS_PORT: 9997
+    depends_on:
+      broker:
+        condition: service_healthy

--- a/kadmin/kadmin.go
+++ b/kadmin/kadmin.go
@@ -27,10 +27,15 @@ type Kadmin interface {
 	TopicConfigLister
 	SraSetter
 	ClusterConfigLister
+	BrokerConfigLister
 }
 
 type ClusterConfigLister interface {
 	GetClusterConfig() (ClusterConfig, error)
+}
+
+type BrokerConfigLister interface {
+	GetBrokerConfig(brokerID int32) (BrokerConfig, error)
 }
 
 type BrokerConfig struct {

--- a/kadmin/kadmin.go
+++ b/kadmin/kadmin.go
@@ -1,8 +1,9 @@
 package kadmin
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
 	"ktea/config"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 const (
@@ -25,6 +26,43 @@ type Kadmin interface {
 	ConfigUpdater
 	TopicConfigLister
 	SraSetter
+	ClusterConfigLister
+}
+
+type ClusterConfigLister interface {
+	GetClusterConfig() (ClusterConfig, error)
+}
+
+type BrokerConfig struct {
+	ID      int32
+	Addr    string
+	Configs map[string]string
+}
+
+type ClusterConfig struct {
+	Brokers []BrokerConfig
+}
+
+type ClusterConfigListingStartedMsg struct {
+	Err     chan error
+	Configs chan ClusterConfig
+}
+
+func (m *ClusterConfigListingStartedMsg) AwaitCompletion() tea.Msg {
+	select {
+	case e := <-m.Err:
+		return ClusterConfigListingErrorMsg{e}
+	case c := <-m.Configs:
+		return ClusterConfigListedMsg{c}
+	}
+}
+
+type ClusterConfigListedMsg struct {
+	Config ClusterConfig
+}
+
+type ClusterConfigListingErrorMsg struct {
+	Err error
 }
 
 type ConnectionDetails struct {

--- a/kadmin/mock.go
+++ b/kadmin/mock.go
@@ -2,8 +2,9 @@ package kadmin
 
 import (
 	"context"
-	tea "github.com/charmbracelet/bubbletea"
 	"ktea/sradmin"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type MockKadmin struct {
@@ -50,6 +51,10 @@ func (m MockKadmin) ListConfigs(topic string) tea.Msg {
 }
 
 func (m MockKadmin) SetSra(sra sradmin.SrAdmin) {
+}
+
+func (m MockKadmin) GetClusterConfig() (ClusterConfig, error) {
+	return ClusterConfig{}, nil
 }
 
 func NewMockKadminInstantiator() Instantiator {

--- a/kadmin/mock.go
+++ b/kadmin/mock.go
@@ -57,6 +57,10 @@ func (m MockKadmin) GetClusterConfig() (ClusterConfig, error) {
 	return ClusterConfig{}, nil
 }
 
+func (m MockKadmin) GetBrokerConfig(brokerID int32) (BrokerConfig, error) {
+	return BrokerConfig{}, nil
+}
+
 func NewMockKadminInstantiator() Instantiator {
 	return func(cd ConnectionDetails) (Kadmin, error) {
 		return &MockKadmin{}, nil

--- a/ui/pages/cluster_config_page/cluster_config_page.go
+++ b/ui/pages/cluster_config_page/cluster_config_page.go
@@ -1,0 +1,120 @@
+package cluster_config_page
+
+import (
+	"fmt"
+	"ktea/config"
+	"ktea/kadmin"
+	"ktea/kontext"
+	"ktea/ui"
+	"ktea/ui/components/statusbar"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/log"
+	"gopkg.in/yaml.v3"
+)
+
+type state int
+
+const (
+	loadingState state = iota
+	loadedState
+	errorState
+)
+
+type Model struct {
+	state    state
+	spinner  spinner.Model
+	viewport *viewport.Model
+	cluster  *config.Cluster
+	configs  kadmin.ClusterConfig
+	err      error
+}
+
+func New(cluster *config.Cluster, ka kadmin.Kadmin) (*Model, tea.Cmd) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	return &Model{
+			state:   loadingState,
+			spinner: s,
+			cluster: cluster,
+		}, func() tea.Msg {
+			log.Info("Fetching cluster configuration", "clusterName", cluster.Name)
+			cfg, err := ka.GetClusterConfig()
+			if err != nil {
+				return kadmin.ClusterConfigListingErrorMsg{Err: err}
+			}
+			return kadmin.ClusterConfigListedMsg{Config: cfg}
+		}
+}
+
+func (m *Model) View(ktx *kontext.ProgramKtx, renderer *ui.Renderer) string {
+	switch m.state {
+	case loadingState:
+		return fmt.Sprintf("%s Loading cluster configuration...", m.spinner.View())
+	case errorState:
+		return fmt.Sprintf("Error: %s", m.err.Error())
+	default:
+		if m.viewport == nil {
+			vp := viewport.New(ktx.WindowWidth-2, ktx.AvailableHeight-1)
+			m.viewport = &vp
+			content := ""
+			for _, broker := range m.configs.Brokers {
+				content += fmt.Sprintf("\nBroker ID: %d\nAddress: %s\n", broker.ID, broker.Addr)
+
+				// Marshal the broker configs to YAML for display
+				configBytes, err := yaml.Marshal(broker.Configs)
+				if err != nil {
+					content += fmt.Sprintf("  Error marshalling configs: %v\n", err)
+				} else {
+					content += fmt.Sprintf("Configs:\n%s\n", string(configBytes))
+				}
+			}
+			m.viewport.SetContent(lipgloss.NewStyle().Padding(1).Render(content))
+		} else {
+			m.viewport.Width = ktx.WindowWidth - 2
+			m.viewport.Height = ktx.AvailableHeight - 1
+		}
+		return m.viewport.View()
+	}
+}
+
+func (m *Model) Update(msg tea.Msg) tea.Cmd {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		cmds = append(cmds, cmd)
+
+	case kadmin.ClusterConfigListedMsg:
+		m.state = loadedState
+		m.configs = msg.Config
+
+	case kadmin.ClusterConfigListingErrorMsg:
+		m.state = errorState
+		m.err = msg.Err
+
+	default:
+		if m.viewport != nil {
+			vp, cmd := m.viewport.Update(msg)
+			m.viewport = &vp
+			cmds = append(cmds, cmd)
+		}
+	}
+
+	return tea.Batch(cmds...)
+}
+
+func (m *Model) Title() string {
+	return "Cluster Configuration"
+}
+
+func (m *Model) Shortcuts() []statusbar.Shortcut {
+	return []statusbar.Shortcut{
+		{"Go Back", "esc"},
+	}
+}

--- a/ui/pages/cluster_config_page/cluster_config_page.go
+++ b/ui/pages/cluster_config_page/cluster_config_page.go
@@ -7,8 +7,10 @@ import (
 	"ktea/kontext"
 	"ktea/ui"
 	"ktea/ui/components/statusbar"
+	ktable "ktea/ui/components/table"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -24,6 +26,13 @@ const (
 	errorState
 )
 
+type viewMode int
+
+const (
+	brokerListMode viewMode = iota
+	brokerDetailMode
+)
+
 type Model struct {
 	state    state
 	spinner  spinner.Model
@@ -31,23 +40,46 @@ type Model struct {
 	cluster  *config.Cluster
 	configs  kadmin.ClusterConfig
 	err      error
+
+	mode           viewMode
+	brokerTable    table.Model
+	selectedBroker *kadmin.BrokerConfig
+	ka             kadmin.Kadmin
 }
 
 func New(cluster *config.Cluster, ka kadmin.Kadmin) (*Model, tea.Cmd) {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
+
+	t := ktable.NewDefaultTable()
+	t.SetColumns([]table.Column{
+		{Title: "ID", Width: 5},
+		{Title: "Address", Width: 30},
+	})
+
 	return &Model{
-			state:   loadingState,
-			spinner: s,
-			cluster: cluster,
-		}, func() tea.Msg {
-			log.Info("Fetching cluster configuration", "clusterName", cluster.Name)
-			cfg, err := ka.GetClusterConfig()
-			if err != nil {
-				return kadmin.ClusterConfigListingErrorMsg{Err: err}
-			}
-			return kadmin.ClusterConfigListedMsg{Config: cfg}
+		state:       loadingState,
+		spinner:     s,
+		cluster:     cluster,
+		mode:        brokerListMode,
+		brokerTable: t,
+		ka:          ka,
+	}, func() tea.Msg {
+		log.Info("Fetching cluster configuration", "clusterName", cluster.Name)
+		cfg, err := ka.GetClusterConfig()
+		if err != nil {
+			return kadmin.ClusterConfigListingErrorMsg{Err: err}
 		}
+		return kadmin.ClusterConfigListedMsg{Config: cfg}
+	}
+}
+
+type BrokerConfigListedMsg struct {
+	Config kadmin.BrokerConfig
+}
+
+type BrokerConfigListingErrorMsg struct {
+	Err error
 }
 
 func (m *Model) View(ktx *kontext.ProgramKtx, renderer *ui.Renderer) string {
@@ -56,29 +88,33 @@ func (m *Model) View(ktx *kontext.ProgramKtx, renderer *ui.Renderer) string {
 		return fmt.Sprintf("%s Loading cluster configuration...", m.spinner.View())
 	case errorState:
 		return fmt.Sprintf("Error: %s", m.err.Error())
-	default:
-		if m.viewport == nil {
-			vp := viewport.New(ktx.WindowWidth-2, ktx.AvailableHeight-1)
-			m.viewport = &vp
-			content := ""
-			for _, broker := range m.configs.Brokers {
-				content += fmt.Sprintf("\nBroker ID: %d\nAddress: %s\n", broker.ID, broker.Addr)
+	case loadedState:
+		switch m.mode {
+		case brokerListMode:
+			m.brokerTable.SetHeight(ktx.AvailableHeight - 1)
+			m.brokerTable.SetWidth(ktx.WindowWidth - 2)
+			return m.brokerTable.View()
+		case brokerDetailMode:
+			if m.viewport == nil {
+				vp := viewport.New(ktx.WindowWidth-2, ktx.AvailableHeight-1)
+				m.viewport = &vp
 
-				// Marshal the broker configs to YAML for display
-				configBytes, err := yaml.Marshal(broker.Configs)
+				content := fmt.Sprintf("Broker ID: %d\nAddress: %s\n\n", m.selectedBroker.ID, m.selectedBroker.Addr)
+				configBytes, err := yaml.Marshal(m.selectedBroker.Configs)
 				if err != nil {
 					content += fmt.Sprintf("  Error marshalling configs: %v\n", err)
 				} else {
 					content += fmt.Sprintf("Configs:\n%s\n", string(configBytes))
 				}
+				m.viewport.SetContent(lipgloss.NewStyle().Padding(1).Render(content))
+			} else {
+				m.viewport.Width = ktx.WindowWidth - 2
+				m.viewport.Height = ktx.AvailableHeight - 1
 			}
-			m.viewport.SetContent(lipgloss.NewStyle().Padding(1).Render(content))
-		} else {
-			m.viewport.Width = ktx.WindowWidth - 2
-			m.viewport.Height = ktx.AvailableHeight - 1
+			return m.viewport.View()
 		}
-		return m.viewport.View()
 	}
+	return ""
 }
 
 func (m *Model) Update(msg tea.Msg) tea.Cmd {
@@ -93,28 +129,87 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case kadmin.ClusterConfigListedMsg:
 		m.state = loadedState
 		m.configs = msg.Config
+		rows := make([]table.Row, len(m.configs.Brokers))
+		for i, broker := range m.configs.Brokers {
+			rows[i] = table.Row{fmt.Sprintf("%d", broker.ID), broker.Addr}
+		}
+		m.brokerTable.SetRows(rows)
 
 	case kadmin.ClusterConfigListingErrorMsg:
 		m.state = errorState
 		m.err = msg.Err
 
-	default:
-		if m.viewport != nil {
-			vp, cmd := m.viewport.Update(msg)
-			m.viewport = &vp
-			cmds = append(cmds, cmd)
+	case BrokerConfigListedMsg:
+		m.state = loadedState
+		m.selectedBroker = &msg.Config
+		m.mode = brokerDetailMode
+		m.viewport = nil
+
+	case BrokerConfigListingErrorMsg:
+		m.state = errorState
+		m.err = msg.Err
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if m.mode == brokerListMode {
+				selectedRow := m.brokerTable.SelectedRow()
+				if selectedRow != nil {
+					brokerIDStr := selectedRow[0]
+					brokerID := 0
+					fmt.Sscanf(brokerIDStr, "%d", &brokerID)
+
+					// Trigger command to fetch single broker config
+					cmds = append(cmds, func() tea.Msg {
+						log.Info("Fetching broker configuration", "brokerID", brokerID)
+						cfg, err := m.ka.GetBrokerConfig(int32(brokerID))
+						if err != nil {
+							return BrokerConfigListingErrorMsg{Err: err}
+						}
+						return BrokerConfigListedMsg{Config: cfg}
+					})
+				}
+			}
+		case "esc":
+			if m.mode == brokerDetailMode {
+				m.mode = brokerListMode
+				m.viewport = nil
+			} else if m.mode == brokerListMode {
+				return func() tea.Msg { return GoBackMsg{} }
+			}
 		}
+	}
+
+	if m.mode == brokerListMode {
+		t, cmd := m.brokerTable.Update(msg)
+		m.brokerTable = t
+		cmds = append(cmds, cmd)
+	} else if m.viewport != nil {
+		vp, cmd := m.viewport.Update(msg)
+		m.viewport = &vp
+		cmds = append(cmds, cmd)
 	}
 
 	return tea.Batch(cmds...)
 }
 
+type GoBackMsg struct{}
+
 func (m *Model) Title() string {
+	if m.mode == brokerDetailMode && m.selectedBroker != nil {
+		return fmt.Sprintf("Broker %d Configuration", m.selectedBroker.ID)
+	}
 	return "Cluster Configuration"
 }
 
 func (m *Model) Shortcuts() []statusbar.Shortcut {
+	if m.mode == brokerDetailMode {
+		return []statusbar.Shortcut{
+			{"Go Back", "esc"},
+		}
+	}
 	return []statusbar.Shortcut{
+		{"View Broker Config", "enter"},
 		{"Go Back", "esc"},
 	}
 }

--- a/ui/pages/clusters_page/clusters_page.go
+++ b/ui/pages/clusters_page/clusters_page.go
@@ -2,10 +2,6 @@ package clusters_page
 
 import (
 	"fmt"
-	"github.com/charmbracelet/bubbles/table"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/log"
 	"ktea/config"
 	"ktea/kadmin"
 	"ktea/kontext"
@@ -19,6 +15,11 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/log"
 )
 
 type Model struct {
@@ -104,6 +105,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 func (m *Model) Shortcuts() []statusbar.Shortcut {
 	return []statusbar.Shortcut{
 		{"Switch Cluster", "enter"},
+		{"View", "C-v"},
 		{"Edit", "C-e"},
 		{"Delete", "F2"},
 		{"Create", "C-n"},

--- a/ui/tabs/clusters_tab/clusters_tab_test.go
+++ b/ui/tabs/clusters_tab/clusters_tab_test.go
@@ -36,7 +36,9 @@ func TestClustersTab(t *testing.T) {
 			Config:       &config.Config{},
 			WindowWidth:  0,
 			WindowHeight: 0,
-		}, mockConnChecker)
+		}, mockConnChecker,
+			kadmin.NewMockKadmin(),
+		)
 
 		// when
 		render := clustersTab.View(&ktx, tests.TestRenderer)
@@ -63,7 +65,7 @@ func TestClustersTab(t *testing.T) {
 				WindowWidth:  100,
 				WindowHeight: 100,
 			}
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 
 			// when
 			render := clustersTab.View(programKtx, tests.TestRenderer)
@@ -104,7 +106,7 @@ func TestClustersTab(t *testing.T) {
 				WindowHeight:    100,
 				AvailableHeight: 100,
 			}
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 
 			// when
 			render := clustersTab.View(programKtx, tests.TestRenderer)
@@ -150,7 +152,7 @@ func TestClustersTab(t *testing.T) {
 				WindowHeight:    100,
 				AvailableHeight: 100,
 			}
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 			// and table has been initialized
 			clustersTab.View(programKtx, tests.TestRenderer)
 
@@ -245,7 +247,7 @@ func TestClustersTab(t *testing.T) {
 
 		t.Run("/ raises search prompt", func(t *testing.T) {
 			// given
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 			// and table has been initialized
 			render := clustersTab.View(programKtx, tests.TestRenderer)
 
@@ -259,7 +261,7 @@ func TestClustersTab(t *testing.T) {
 
 		t.Run("F2 raises delete confirmation", func(t *testing.T) {
 			// given
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 			// and table has been initialized
 			render := clustersTab.View(programKtx, tests.TestRenderer)
 
@@ -273,7 +275,7 @@ func TestClustersTab(t *testing.T) {
 
 		t.Run("esc cancels raised delete confirmation", func(t *testing.T) {
 			// given
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 			// and table has been initialized
 			render := clustersTab.View(programKtx, tests.TestRenderer)
 			// and delete confirmation has been raised
@@ -291,7 +293,7 @@ func TestClustersTab(t *testing.T) {
 
 		t.Run("enter deletes cluster", func(t *testing.T) {
 			// given
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 			// and table has been initialized
 			render := clustersTab.View(programKtx, tests.TestRenderer)
 
@@ -338,7 +340,7 @@ func TestClustersTab(t *testing.T) {
 				AvailableHeight: 100,
 			}
 			// and
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 			// and table has been initialized
 			render := clustersTab.View(programKtx, tests.TestRenderer)
 
@@ -389,7 +391,7 @@ func TestClustersTab(t *testing.T) {
 
 		t.Run("c-e opens edit page", func(t *testing.T) {
 			// given
-			var clustersTab, _ = New(programKtx, mockConnChecker)
+			var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 			// and table has been initialized
 			clustersTab.View(programKtx, tests.TestRenderer)
 
@@ -435,7 +437,7 @@ func TestClustersTab(t *testing.T) {
 			WindowWidth:  100,
 			WindowHeight: 100,
 		}
-		var clustersTab, _ = New(programKtx, mockConnChecker)
+		var clustersTab, _ = New(programKtx, mockConnChecker, kadmin.NewMockKadmin())
 		clustersTab.View(programKtx, tests.TestRenderer)
 
 		// when


### PR DESCRIPTION
This PR adds a new shortcut view `(Ctrl+V)` to display the cluster configuration under `Clusters` tab. It currently lists all brokers in the cluster, and users can view the configuration of a selected broker by pressing `Enter`.


![image](https://github.com/user-attachments/assets/a9e2009f-3e85-47bb-9a3b-85449cc92fec)

![image](https://github.com/user-attachments/assets/fb8efd9a-0f7d-4b09-93f0-50a5d9602b93)

![image](https://github.com/user-attachments/assets/43a7ba0f-0c80-49c4-b554-95cb60549738)
