### PR TITLE
feat(clusterconfig): Add kadmin changes for listing broker and fetching broker configuration

### DIFF
--- a/cmd/ktea/main.go
+++ b/cmd/ktea/main.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"flag"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/log"
 	"ktea/config"
 	"ktea/kadmin"
 	"ktea/kcadmin"
@@ -23,6 +20,10 @@ import (
 	"os"
 	"slices"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/log"
 )
 
 var version string
@@ -152,6 +153,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		c := m.boostrapUI(msg.Cluster)
 		return m, c
 
+	case kadmin.ClusterConfigMsg, kadmin.ClusterConfigStartedMsg:
+		if m.clustersTabCtrl != nil {
+			return m, m.clustersTabCtrl.Update(msg)
+		}
 	case config.LoadedMsg:
 		m.ktx.Config = msg.Config
 		if m.ktx.Config.HasClusters() {

--- a/kadmin/cluster_config.go
+++ b/kadmin/cluster_config.go
@@ -1,0 +1,148 @@
+package kadmin
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/IBM/sarama"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/log"
+)
+
+type ClusterConfigLister interface {
+	GetClusterConfig() tea.Msg
+}
+
+type BrokerConfigLister interface {
+	GetBrokerConfig(brokerID int32) tea.Msg
+}
+
+type Broker struct {
+	ID      int32
+	Address string
+}
+
+type ClusterConfig struct {
+	Brokers []Broker
+}
+
+type ClusterConfigStartedMsg struct {
+	Err     chan error
+	Configs chan ClusterConfig
+}
+
+func (m *ClusterConfigStartedMsg) AwaitCompletion() tea.Msg {
+	select {
+	case e := <-m.Err:
+		return ClusterConfigErrorMsg{e}
+	case c := <-m.Configs:
+		return ClusterConfigMsg{c}
+	}
+}
+
+type ClusterConfigMsg struct {
+	Config ClusterConfig
+}
+type ClusterConfigErrorMsg struct {
+	Err error
+}
+
+// GetClusterConfig retrieves the configuration of the Kafka cluster
+func (ka *SaramaKafkaAdmin) GetClusterConfig() tea.Msg {
+	MaybeIntroduceLatency()
+	errChan := make(chan error)
+	configsChan := make(chan ClusterConfig)
+	go ka.doGetClusterConfig(errChan, configsChan)
+	log.Debug("Cluster configuration retrieval started")
+	return ClusterConfigStartedMsg{
+		Err:     errChan,
+		Configs: configsChan,
+	}
+}
+
+func (ka *SaramaKafkaAdmin) doGetClusterConfig(errChan chan error, configsChan chan ClusterConfig) {
+	log.Debug("Fetching cluster configuration...")
+	saramaBrokers, _, err := ka.admin.DescribeCluster()
+	if err != nil {
+		log.Error("Failed to describe cluster", "error", err)
+		errChan <- err
+		return
+	}
+	sort.Slice(saramaBrokers, func(i, j int) bool {
+		return saramaBrokers[i].ID() < saramaBrokers[j].ID()
+	})
+	brokers := make([]Broker, 0)
+	for _, saramaBroker := range saramaBrokers {
+		brokers = append(brokers, Broker{
+			ID:      saramaBroker.ID(),
+			Address: saramaBroker.Addr(),
+		})
+	}
+	log.Debug("Cluster configuration fetched successfully", "brokers", len(brokers))
+	configsChan <- ClusterConfig{Brokers: brokers}
+	close(configsChan)
+}
+
+type BrokerConfigListingStartedMsg struct {
+	Err     chan error
+	Configs chan BrokerConfig
+}
+
+type BrokerConfig struct {
+	ID      int32
+	Configs map[string]string
+}
+
+type BrokerConfigListedMsg struct {
+	Config BrokerConfig
+}
+
+type BrokerConfigErrorMsg struct {
+	Err error
+}
+
+func (m *BrokerConfigListingStartedMsg) AwaitCompletion() tea.Msg {
+	select {
+	case e := <-m.Err:
+		return BrokerConfigErrorMsg{e}
+	case c := <-m.Configs:
+		return BrokerConfigListedMsg{c}
+	}
+}
+
+// GetBrokerConfig retrieves the configuration for a specific broker in the Kafka cluster
+func (ka *SaramaKafkaAdmin) GetBrokerConfig(brokerID int32) tea.Msg {
+	MaybeIntroduceLatency()
+	log.Debug("Fetching config for broker", "brokerID", brokerID)
+	errChan := make(chan error)
+	configsChan := make(chan BrokerConfig)
+	go ka.doGetBrokerConfig(brokerID, errChan, configsChan)
+	log.Debug("Broker configuration retrieval started", "brokerID", brokerID)
+	return BrokerConfigListingStartedMsg{
+		Err:     errChan,
+		Configs: configsChan,
+	}
+}
+
+func (ka *SaramaKafkaAdmin) doGetBrokerConfig(brokerID int32, errChan chan error, configsChan chan BrokerConfig) {
+	log.Debug("Fetching broker config", "brokerID", brokerID)
+	resource := sarama.ConfigResource{
+		Type: sarama.BrokerResource,
+		Name: fmt.Sprintf("%d", brokerID),
+	}
+
+	entries, err := ka.admin.DescribeConfig(resource)
+	if err != nil {
+		log.Error("Failed to describe broker config", "brokerID", brokerID, "error", err)
+		errChan <- err
+		return
+	}
+
+	configMap := make(map[string]string)
+	for _, entry := range entries {
+		configMap[entry.Name] = entry.Value
+	}
+
+	configsChan <- BrokerConfig{ID: brokerID, Configs: configMap}
+	close(configsChan)
+}

--- a/kadmin/cluster_config_test.go
+++ b/kadmin/cluster_config_test.go
@@ -1,0 +1,85 @@
+package kadmin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetClusterConfig(t *testing.T) {
+	t.Run("Get cluster config", func(t *testing.T) {
+		// when
+		msg := ka.GetClusterConfig()
+		startedMsg, ok := msg.(ClusterConfigStartedMsg)
+		assert.True(t, ok, "expected ClusterConfigStartedMsg")
+
+		// then
+		select {
+		case result := <-startedMsg.Configs:
+			assert.Len(t, result.Brokers, 1, "Expected 1 broker")
+			assert.NotNil(t, result.Brokers[0].ID, "Broker ID should not be nil")
+			assert.NotEmpty(t, result.Brokers[0].Address, "Broker address should not be empty")
+		case err := <-startedMsg.Err:
+			t.Fatal("Error while getting cluster config", err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Test timed out waiting for cluster config")
+		}
+	})
+}
+
+func TestGetBrokerConfig(t *testing.T) {
+	t.Run("Get broker config", func(t *testing.T) {
+		// given
+		// Get the broker ID from the cluster config
+		msg := ka.GetClusterConfig()
+		startedMsg, ok := msg.(ClusterConfigStartedMsg)
+		assert.True(t, ok, "expected ClusterConfigStartedMsg")
+
+		var brokerID int32
+		select {
+		case result := <-startedMsg.Configs:
+			assert.Len(t, result.Brokers, 1, "Expected 1 broker")
+			brokerID = result.Brokers[0].ID
+		case err := <-startedMsg.Err:
+			t.Fatal("Error while getting cluster config for broker test", err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Test timed out waiting for cluster config for broker test")
+		}
+
+		// when
+		brokerMsg := ka.GetBrokerConfig(brokerID)
+		brokerStartedMsg, ok := brokerMsg.(BrokerConfigListingStartedMsg)
+		assert.True(t, ok, "expected BrokerConfigListingStartedMsg")
+
+		// then
+		select {
+		case result := <-brokerStartedMsg.Configs:
+			assert.Equal(t, brokerID, result.ID)
+			assert.NotEmpty(t, result.Configs, "Expected broker config to not be empty")
+		case err := <-brokerStartedMsg.Err:
+			t.Fatal("Error while getting broker config", err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Test timed out waiting for broker config")
+		}
+	})
+}
+
+func TestGetBrokerConfig_Error(t *testing.T) {
+	t.Run("Get broker config with non-existent broker ID", func(t *testing.T) {
+		// when
+		brokerMsg := ka.GetBrokerConfig(999)
+		brokerStartedMsg, ok := brokerMsg.(BrokerConfigListingStartedMsg)
+		assert.True(t, ok, "expected BrokerConfigListingStartedMsg")
+
+		// then
+		select {
+		case <-brokerStartedMsg.Configs:
+			t.Fatal("Expected an error but got broker config instead")
+		case err := <-brokerStartedMsg.Err:
+			assert.Error(t, err, "Expected an error")
+		case <-time.After(5 * time.Second):
+			t.Fatal("Test timed out waiting for broker config error")
+		}
+	})
+}

--- a/kadmin/kadmin.go
+++ b/kadmin/kadmin.go
@@ -1,8 +1,9 @@
 package kadmin
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
 	"ktea/config"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 const (
@@ -25,6 +26,8 @@ type Kadmin interface {
 	ConfigUpdater
 	TopicConfigLister
 	SraSetter
+	ClusterConfigLister
+	BrokerConfigLister
 }
 
 type ConnectionDetails struct {

--- a/kadmin/mock.go
+++ b/kadmin/mock.go
@@ -2,9 +2,10 @@ package kadmin
 
 import (
 	"context"
-	tea "github.com/charmbracelet/bubbletea"
 	"ktea/config"
 	"ktea/sradmin"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type MockKadmin struct {
@@ -59,6 +60,14 @@ func (m MockKadmin) ListConfigs(topic string) tea.Msg {
 }
 
 func (m MockKadmin) SetSra(sra sradmin.SrAdmin) {
+}
+
+func (m MockKadmin) GetClusterConfig() tea.Msg {
+	return nil
+}
+
+func (m MockKadmin) GetBrokerConfig(brokerID int32) tea.Msg {
+	return nil
 }
 
 func NewMockKadminInstantiator() Instantiator {


### PR DESCRIPTION
This PR adds kadmin changes for listing broker and fetching broker configuration.

- Adds `ClusterConfigLister` and `BrokerConfigLister` to the `Kadmin` interface.
- Implements the new functionality in `kadmin/cluster_config.go`.
- Hooks the new messages into the main UI loop in `cmd/ktea/main.go`.
- Includes integration tests for the new functionality, covering both success and error cases.

previous pr ref - https://github.com/jonas-grgt/ktea/pull/50