### PR TITLE
feat: Error message colors reset

### DIFF
--- a/styles/styles.go
+++ b/styles/styles.go
@@ -290,7 +290,6 @@ func init() {
 			MarginBottom(0).
 			MarginLeft(2).
 			Height(1).
-			Foreground(lipgloss.Color(ColorRed)).
 			Bold(true)
 
 	}


### PR DESCRIPTION
- Error message colors are reset when new line starts #58 
- As-Is
<img width="993" height="149" alt="스크린샷 2025-09-24 오후 11 20 03" src="https://github.com/user-attachments/assets/0a493550-b66b-4eab-9f04-be1af01887cf" />
- To-Be
<img width="906" height="359" alt="스크린샷 2025-09-25 오후 6 23 52" src="https://github.com/user-attachments/assets/4cc3c42e-3677-481d-867c-d3646e761e89" />
