### PR TITLE
README: config file as yaml and not conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ All tables can be navigated using vi like bindings:
 
 ### Configuration
 
-All configuration is stored in `~/.config/ktea/config.conf`
+All configuration is stored in `~/.config/ktea/config.yaml`
 
 All cluster configuration can be managed through the TUI even the initial one.
 


### PR DESCRIPTION
Just downloaded the linux version and the config file has the yaml extension and not conf.

As seen in file.go it should be yaml
```go
	configPath := filepath.Join(homeDir, ".config", "ktea", "config.yaml")
```